### PR TITLE
Set objects public

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Yoggi uses AWS S3 to store the files. The frontend is written in React.
 1. Install Python
 1. Run `npm install` (the `postinstall` script will run `npm run build`, which builds frontend)
 1. Configure your environment variables in an `.env`-file, see [Environment variables](#environment-variables)
+1. Change `'REACT_APP_BUCKET_NAME': JSON.stringify('dsekt-assets')` to `'REACT_APP_BUCKET_NAME': JSON.stringify('dsekt-assets-dev')` in [webpack-production.config.js](/webpack-production.config.js), if you are running `npm run build` to test locally
 1. Run `pipenv install`
 1. Run `pipenv shell` which loads environment variables and some other magic
 1. Run python yoggi.py
@@ -27,6 +28,28 @@ To get a login key, or access to the `dsekt-assets-dev`-bucket, ask Systemansvar
 | S3_BUCKET                      | Name of S3 bucket. When running locally, use `dsekt-assets-dev` | --- |
 | AWS_ACCESS_KEY_ID              | AWS IAM access key id           | ---                              |
 | AWS_SECRET_ACCESS_KEY          | AWS IAM secret access key       | ---                              |
+
+# Configuring the S3 bucket
+
+Objects can be set as publicly accessible by adding the tag key-value-pair "public": "True" to the object. For this to work, the bucket needs to be configured with the following JSON (Bucket policy):
+```JSON
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::dsekt-assets/*",
+            "Condition": {
+                "StringEquals": {
+                    "s3:ExistingObjectTag/public": "True"
+                }
+            }
+        }
+    ]
+}
+```
 
 # Protip
 To allow larger file uploads, set the max size of file uploads to for example 100 MB.

--- a/s3.py
+++ b/s3.py
@@ -69,7 +69,7 @@ def put(path, file, owner, mimetype, public):
         Tagging="public=" + str(public)
     )
 
-def putPermissions(path, public):
+def put_permissions(path, public):
     if not exists(path):
         return False
     

--- a/s3.py
+++ b/s3.py
@@ -24,7 +24,17 @@ def list(prefix):
     files = [x['Key'] for x in response['Contents']] if 'Contents' in response else []
     folders = [x['Prefix'] for x in response['CommonPrefixes']] if 'CommonPrefixes' in response else []
 
-    return {'files': files, 'folders': folders}
+    # Apparently you can't get tags from list_objects...
+    tags = {}
+    for f in files:
+        file_tags = client.get_object_tagging(
+            Bucket=BUCKET,
+            Key=f
+        )
+
+        tags[f] = file_tags["TagSet"] or [{'Key': 'public', 'Value': 'False'}]
+
+    return {'files': files, 'folders': folders, 'tags': tags}
 
 
 def get(path):
@@ -42,7 +52,7 @@ def get_url(path):
             ExpiresIn=60*60*24*365)
 
 
-def put(path, file, owner, mimetype):
+def put(path, file, owner, mimetype, public):
     if exists(path):
         return False
 
@@ -55,9 +65,26 @@ def put(path, file, owner, mimetype):
         Metadata={
             'owner': owner,
             'filename': quote(file.filename)
-        }
+        },
+        Tagging="public=" + str(public)
     )
 
+def putPermissions(path, public):
+    if not exists(path):
+        return False
+    
+    return client.put_object_tagging(
+        Bucket=BUCKET,
+        Key=path,
+        Tagging={
+            'TagSet': [
+                {
+                    'Key': 'public',
+                    'Value': str(public)
+                }
+            ]
+        }
+    )
 
 def delete(path):
     if not exists(path):

--- a/src/app/Browser.js
+++ b/src/app/Browser.js
@@ -114,8 +114,7 @@ function FileItem(props) {
 
   
   const isPublic = tags
-                  .filter(t => t["Key"] === "public")
-                  .map(t => t["Value"])[0]
+                  .filter(t => t["Key"] === "public")[0]["Value"]
                   .toLowerCase() === "true"
   
   const AccessibleIcon = (

--- a/src/app/Browser.js
+++ b/src/app/Browser.js
@@ -111,7 +111,7 @@ function FileItem(props) {
 
 
   return (
-    <a href={`/${name}`}> <ListItem
+    <a href={`/${name}`} target="_blank" rel="noopener noreferrer"> <ListItem
       primaryText={name}
       rightIconButton={
         <div>

--- a/src/app/Browser.js
+++ b/src/app/Browser.js
@@ -12,10 +12,12 @@ import Divider from 'material-ui/Divider';
 
 import IconButton from 'material-ui/IconButton'
 import ActionDelete from 'material-ui/svg-icons/action/delete'
-import FontIcon from 'material-ui/FontIcon';
+import LockClosed from 'material-ui/svg-icons/action/lock';
+import LockOpen from 'material-ui/svg-icons/action/lock-open';
+import LinkIcon from 'material-ui/svg-icons/editor/insert-link';
 
 function Browser(props) {
-  const { folder, files, folders, token, changeFolder, onDelete } = props
+  const { folder, files, folders, token, changeFolder, onDelete, tags, onPublicSet } = props
 
   return (<div>
     <Subheader>{folder}</Subheader>
@@ -34,6 +36,8 @@ function Browser(props) {
         name={file}
         token={token}
         onDelete={onDelete}
+        tags={tags[file]}
+        onPublicSet={onPublicSet}
       />)}
     </List>
   </div>)
@@ -50,7 +54,7 @@ function FolderItem(props) {
 }
 
 function FileItem(props) {
-  const { name, onDelete } = props
+  const { name, onDelete, tags, onPublicSet } = props
 
   const deleteFile = e => {
     e.preventDefault()
@@ -60,10 +64,11 @@ function FileItem(props) {
 
   const deleteButton = (
     <IconButton
+      title="Radera"
       style={{ boxShadow: 'none' }}
       hoveredStyle={{ boxShadow: 'none' }}
       onClick={deleteFile}>
-      <ActionDelete />
+      <ActionDelete hoverColor="#ff5722" />
     </IconButton>
   )
   const constructShortUrl = (short) => window.location.origin + "/" + short;
@@ -95,6 +100,7 @@ function FileItem(props) {
 
   const copyButton = (
     <IconButton
+      title="Kopiera länk"
       style={{ boxShadow: 'none' }}
       hoveredStyle={{ boxShadow: 'none' }}
       onClick={(e) => {
@@ -102,23 +108,46 @@ function FileItem(props) {
         e.stopPropagation()
         copyToClipboard(name)
       }}>
-      <FontIcon
-        className="fas fa-link fa-xs"
-      >
-      </FontIcon>
+      <LinkIcon hoverColor="#ff5722" />
     </IconButton>
   )
 
+  
+  const isPublic = tags
+                  .filter(t => t["Key"] === "public")
+                  .map(t => t["Value"])[0]
+                  .toLowerCase() === "true"
+  
+  const AccessibleIcon = (
+    <IconButton
+      style={{ boxShadow: 'none' }}
+      hoveredStyle={{ boxShadow: 'none' }}
+      title={isPublic ? "Öppen för alla på internet" : "Ej öppen för alla på internet, åtkomst via yoggi krävs."}
+      onClick={e => {
+        e.preventDefault()
+        e.stopPropagation()
+        onPublicSet(name, isPublic)
+      }}
+    >
+      {isPublic ?
+        <LockOpen hoverColor="#ff5722" />
+        :
+        <LockClosed hoverColor="#ff5722" />
+      }
+    </IconButton>
+  )
 
   return (
-    <a href={`/${name}`} target="_blank" rel="noopener noreferrer"> <ListItem
-      primaryText={name}
-      rightIconButton={
-        <div>
-          {copyButton}
-          {deleteButton}
-        </div>}
-    />
+    <a href={isPublic ? `https://${process.env.REACT_APP_BUCKET_NAME}.s3.amazonaws.com/${name}` : `/${name}`} target="_blank" rel="noopener noreferrer">
+      <ListItem
+        primaryText={name}
+        rightIconButton={
+          <div>
+            {copyButton}
+            {AccessibleIcon}
+            {deleteButton}
+          </div>}
+      />
     </a>
   )
 }

--- a/src/app/Browser.js
+++ b/src/app/Browser.js
@@ -68,7 +68,7 @@ function FileItem(props) {
       style={{ boxShadow: 'none' }}
       hoveredStyle={{ boxShadow: 'none' }}
       onClick={deleteFile}>
-      <ActionDelete hoverColor="#ff5722" />
+      <ActionDelete hoverColor={deepOrange500} />
     </IconButton>
   )
   const constructShortUrl = (short) => window.location.origin + "/" + short;
@@ -108,7 +108,7 @@ function FileItem(props) {
         e.stopPropagation()
         copyToClipboard(name)
       }}>
-      <LinkIcon hoverColor="#ff5722" />
+      <LinkIcon hoverColor={deepOrange500} />
     </IconButton>
   )
 
@@ -129,9 +129,9 @@ function FileItem(props) {
       }}
     >
       {isPublic ?
-        <LockOpen hoverColor="#ff5722" />
+        <LockOpen hoverColor={deepOrange500} />
         :
-        <LockClosed hoverColor="#ff5722" />
+        <LockClosed hoverColor={deepOrange500} />
       }
     </IconButton>
   )

--- a/src/app/Main.js
+++ b/src/app/Main.js
@@ -83,7 +83,6 @@ class Main extends Component {
     .then(response => response.text())
     .then(text => {
       this.setState({ response: text })
-      console.log(text)
       this.list(folder)
     })
   }
@@ -98,7 +97,6 @@ class Main extends Component {
         .then(response => response.text())
         .then(text => {
           this.setState({response: text, open: false, filename: false})
-          console.log(text)
           this.list(folder)
         })
     }
@@ -107,7 +105,6 @@ class Main extends Component {
   onDelete = res => {
     res.text().then(text => {
       this.setState({response: text})
-      console.log(text)
       this.list(this.state.folder)
     })
   }

--- a/src/app/Main.js
+++ b/src/app/Main.js
@@ -260,7 +260,7 @@ function Upload(props) {
       primary={isPublic}
       containerElement='label'
       label={'Ladda upp som publik: ' + (isPublic ? "Ja" : "Nej")}
-      onClick={() => setPublic(isPublic === true ? false : true)}
+      onClick={() => setPublic(!isPublic)}
       title="Publika filer kan nås av vem som helst på internet"
     >
     </RaisedButton>

--- a/webpack-dev-server.config.js
+++ b/webpack-dev-server.config.js
@@ -28,6 +28,11 @@ const config = {
   plugins: [
     // Enables Hot Modules Replacement
     new webpack.HotModuleReplacementPlugin(),
+    new webpack.DefinePlugin({
+      'process.env':{
+        'REACT_APP_BUCKET_NAME': JSON.stringify('dsekt-assets-dev'),
+      }
+    }),
     // Allows error warnings but does not stop compiling.
     new webpack.NoErrorsPlugin(),
     // Moves files

--- a/webpack-production.config.js
+++ b/webpack-production.config.js
@@ -17,7 +17,9 @@ const config = {
     // Define production build to allow React to strip out unnecessary checks
     new webpack.DefinePlugin({
       'process.env':{
-        'NODE_ENV': JSON.stringify('production')
+        'NODE_ENV': JSON.stringify('production'),
+        // Change this when developing locally to dsekt-assets-dev
+        'REACT_APP_BUCKET_NAME': JSON.stringify('dsekt-assets'),
       }
     }),
     // Minify the bundle

--- a/yoggi.py
+++ b/yoggi.py
@@ -159,7 +159,7 @@ class S3Handler:
 
         if self.has_access(response, path):
 
-            s3.putPermissions(path, state)
+            s3.put_permissions(path, state)
             response.data = 'That probably worked...'
 
         else:


### PR DESCRIPTION
This PR adds the ability to make objects publicly accessible with the click of a button.

![image](https://user-images.githubusercontent.com/33149910/142001064-3d92485c-5ee0-4fa3-bb80-82bba111b4a6.png)


The way this works is that we add the tag key-value-pair "`public": "True/False"` (`True` for publicly accessible) to the object. By then adding the following policy to the bucket, all objects with the `public: True`-tag will be publicly accessible:
```JSON
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Principal": "*",
            "Action": "s3:GetObject",
            "Resource": "arn:aws:s3:::dsekt-assets/*",
            "Condition": {
                "StringEquals": {
                    "s3:ExistingObjectTag/public": "True"
                }
            }
        }
    ]
}
```

Since ea66e6275744a735c6fe325343003d65549fc653 yoggi is put behind auth. Therefore images linked from for example our website (for example the images on [namnder/mottagningen](https://datasektionen.se/namnder/mottagningen) wouldn't be visible. The way to work around this was to use the `s3.dsekt-assets.amazonaws.com`-link instead of the `yoggi`-link. Additionally, you would have to manually configure the bucket (in the AWS console) to make the object publicly accessible. After this configuration, the object could be publicly accessible.

For example:
[dadderiet.svg](https://dsekt-assets.s3-eu-west-1.amazonaws.com/mottagningen/dadderiet.svg) is publicly readable, [budget_sm_2020](https://dsekt-assets.s3.amazonaws.com/protokoll/budget_sm_2020) is not.

I do not know why it was decided to put yoggi behind auth, I remember that someone mentioned in one of our meetings that there was sensitive data on yoggi. Is there?